### PR TITLE
chore: update packages (fixes xml2js vulnerability)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,5 +45,6 @@ module.exports = function parseBMFontXML(data) {
       }
     }
   })
-  return output
+  var outputJSON = JSON.parse(JSON.stringify(output))
+  return outputJSON
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-bmfont-xml",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "parses XML BMFont files into a JavaScript object",
   "main": "lib/index.js",
   "browser": "lib/browser.js",
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "xml-parse-from-string": "^1.0.0",
-    "xml2js": "^0.4.5"
+    "xml2js": "^0.5.0"
   },
   "devDependencies": {
-    "brfs": "^1.4.0",
-    "browserify": "^9.0.3",
-    "faucet": "0.0.1",
-    "tape": "^3.5.0",
+    "brfs": "^2.0.2",
+    "browserify": "^17.0.0",
+    "faucet": "0.0.4",
+    "tape": "^5.6.3",
     "testling": "^1.7.1",
     "xhr": "^2.0.1"
   },


### PR DESCRIPTION
There was a vulnerability reported recently in `xml2js` package: https://github.com/Leonidas-from-XIV/node-xml2js/issues/663.
It was fixed in v0.5.0 with this PR: https://github.com/Leonidas-from-XIV/node-xml2js/pull/603.
Using v0.5.0 adds `[Object: null prototype]` to every object, so I added `JSON.parse(JSON.stringify(output))` in order not to break/change the functionality of `parse-bmfront-xml`.

P.S.: I just saw that there's already a PR for this (https://github.com/mattdesl/parse-bmfont-xml/pull/4)
P.P.S.: This will close https://github.com/mattdesl/parse-bmfont-xml/issues/6